### PR TITLE
Build markdown-driven knowledge base

### DIFF
--- a/css/knowledge-base.css
+++ b/css/knowledge-base.css
@@ -1,0 +1,774 @@
+:root {
+  --kb-font-body: 'Inter', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --kb-font-heading: 'Poppins', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  --kb-background: #f5f7fb;
+  --kb-surface: #ffffff;
+  --kb-surface-soft: #f0f3f8;
+  --kb-border: rgba(60, 66, 87, 0.12);
+  --kb-border-strong: rgba(60, 66, 87, 0.24);
+  --kb-text: #1f2430;
+  --kb-text-subtle: #5b6170;
+  --kb-accent: #2563eb;
+  --kb-accent-strong: #1d4ed8;
+  --kb-success: #16a34a;
+  --kb-warning: #d97706;
+  --kb-tag-bg: rgba(37, 99, 235, 0.08);
+  --kb-tag-text: #2563eb;
+  --kb-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  --kb-shadow-soft: 0 4px 12px rgba(15, 23, 42, 0.05);
+  --kb-radius-lg: 24px;
+  --kb-radius-md: 16px;
+  --kb-radius-sm: 10px;
+  --kb-max-width: 1100px;
+  --kb-transition: 180ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --kb-background: #0f172a;
+    --kb-surface: #111c33;
+    --kb-surface-soft: #172340;
+    --kb-border: rgba(148, 163, 184, 0.18);
+    --kb-border-strong: rgba(148, 163, 184, 0.36);
+    --kb-text: #e2e8f0;
+    --kb-text-subtle: #94a3b8;
+    --kb-accent: #60a5fa;
+    --kb-accent-strong: #3b82f6;
+    --kb-tag-bg: rgba(96, 165, 250, 0.12);
+    --kb-tag-text: #93c5fd;
+    --kb-shadow: 0 20px 40px rgba(8, 47, 73, 0.45);
+    --kb-shadow-soft: 0 10px 30px rgba(8, 47, 73, 0.35);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--kb-font-body);
+  color: var(--kb-text);
+  background: var(--kb-background);
+  min-height: 100vh;
+}
+
+a {
+  color: var(--kb-accent-strong);
+  text-decoration: none;
+  transition: color var(--kb-transition);
+}
+
+a:hover,
+a:focus {
+  color: var(--kb-accent);
+}
+
+.kb-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: linear-gradient(120deg, rgba(37, 99, 235, 0.95), rgba(79, 70, 229, 0.92));
+  box-shadow: var(--kb-shadow-soft);
+  backdrop-filter: blur(20px);
+}
+
+.kb-header .container {
+  width: min(1200px, 92vw);
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 0;
+}
+
+.brand {
+  font-family: var(--kb-font-heading);
+  font-weight: 700;
+  font-size: 1.25rem;
+  color: #f8fafc;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.brand svg {
+  width: 28px;
+  height: 28px;
+  fill: currentColor;
+}
+
+.kb-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.kb-nav a {
+  color: rgba(248, 250, 252, 0.9);
+  font-weight: 500;
+}
+
+.kb-nav a:hover,
+.kb-nav a:focus {
+  color: #fef3c7;
+}
+
+main#kb-app {
+  width: min(var(--kb-max-width), 92vw);
+  margin: 0 auto;
+  padding: 56px 0 96px;
+  display: grid;
+  gap: 64px;
+}
+
+.hero {
+  background: var(--kb-surface);
+  border-radius: var(--kb-radius-lg);
+  box-shadow: var(--kb-shadow);
+  padding: 56px clamp(24px, 4vw, 64px);
+  display: grid;
+  gap: 24px;
+  position: relative;
+  overflow: hidden;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: auto -160px -160px auto;
+  width: 320px;
+  height: 320px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(37, 99, 235, 0.25), rgba(37, 99, 235, 0));
+  pointer-events: none;
+}
+
+.hero h1 {
+  font-family: var(--kb-font-heading);
+  font-weight: 700;
+  font-size: clamp(2.25rem, 4vw, 3.2rem);
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.hero p {
+  font-size: clamp(1rem, 2.5vw, 1.2rem);
+  max-width: 48ch;
+  color: var(--kb-text-subtle);
+  line-height: 1.6;
+}
+
+.hero .quick-stats {
+  display: flex;
+  gap: 32px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.hero .quick-stats .stat {
+  display: grid;
+  gap: 4px;
+  font-size: 0.95rem;
+}
+
+.hero .quick-stats .stat strong {
+  font-size: 1.4rem;
+  font-weight: 600;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.hero-actions a.primary {
+  background: var(--kb-accent);
+  color: #f8fafc;
+  padding: 14px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: var(--kb-shadow-soft);
+}
+
+.hero-actions a.secondary {
+  border: 1px solid var(--kb-border);
+  color: var(--kb-text);
+  padding: 14px 24px;
+  border-radius: 999px;
+  font-weight: 600;
+  background: var(--kb-surface-soft);
+}
+
+.tools {
+  display: grid;
+  gap: 18px;
+}
+
+.search-bar {
+  position: relative;
+}
+
+.search-bar label {
+  display: block;
+  font-weight: 600;
+  color: var(--kb-text-subtle);
+  margin-bottom: 8px;
+}
+
+.search-bar input[type="search"] {
+  width: 100%;
+  padding: 16px 56px 16px 52px;
+  border-radius: var(--kb-radius-md);
+  border: 1px solid var(--kb-border);
+  background: var(--kb-surface);
+  font-size: 1rem;
+  color: var(--kb-text);
+  box-shadow: var(--kb-shadow-soft);
+}
+
+.search-bar svg {
+  position: absolute;
+  top: 50%;
+  left: 18px;
+  width: 22px;
+  height: 22px;
+  fill: var(--kb-text-subtle);
+  transform: translateY(-50%);
+}
+
+.search-bar input[type="search"]:focus {
+  outline: 3px solid rgba(37, 99, 235, 0.2);
+  border-color: var(--kb-accent);
+}
+
+.result-count {
+  color: var(--kb-text-subtle);
+  font-weight: 500;
+}
+
+#active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.filter-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--kb-border);
+  background: var(--kb-surface);
+  font-size: 0.9rem;
+}
+
+.filter-pill button {
+  border: none;
+  background: none;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: var(--kb-text-subtle);
+  line-height: 1;
+}
+
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.tag-cloud button {
+  border: none;
+  background: var(--kb-tag-bg);
+  color: var(--kb-tag-text);
+  padding: 10px 16px;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform var(--kb-transition), box-shadow var(--kb-transition), background var(--kb-transition);
+}
+
+.tag-cloud button:hover,
+.tag-cloud button:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--kb-shadow-soft);
+}
+
+.tag-cloud button[data-active="true"] {
+  background: var(--kb-accent);
+  color: #f8fafc;
+  box-shadow: var(--kb-shadow-soft);
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+  gap: 24px;
+}
+
+.kb-card {
+  background: var(--kb-surface);
+  border-radius: var(--kb-radius-lg);
+  padding: 28px;
+  display: grid;
+  gap: 16px;
+  box-shadow: var(--kb-shadow-soft);
+  border: 1px solid transparent;
+  transition: transform var(--kb-transition), box-shadow var(--kb-transition), border var(--kb-transition);
+}
+
+.kb-card:hover,
+.kb-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: var(--kb-shadow);
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
+.kb-card .category {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--kb-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.kb-card h3 {
+  font-family: var(--kb-font-heading);
+  font-weight: 600;
+  font-size: 1.35rem;
+  margin: 0;
+}
+
+.kb-card p {
+  color: var(--kb-text-subtle);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.kb-card .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: var(--kb-text-subtle);
+}
+
+.kb-card .tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.kb-card .tags span {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--kb-surface-soft);
+  color: var(--kb-text-subtle);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.kb-card a.read-more {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--kb-accent);
+}
+
+.kb-card a.read-more svg {
+  width: 18px;
+  height: 18px;
+  transform: translateX(0);
+  transition: transform var(--kb-transition);
+}
+
+.kb-card a.read-more:hover svg,
+.kb-card a.read-more:focus svg {
+  transform: translateX(4px);
+}
+
+#empty-state,
+#error-state {
+  background: var(--kb-surface);
+  border-radius: var(--kb-radius-lg);
+  padding: 36px;
+  box-shadow: var(--kb-shadow-soft);
+  border: 1px dashed var(--kb-border);
+  text-align: center;
+  color: var(--kb-text-subtle);
+  display: grid;
+  gap: 12px;
+}
+
+#kb-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--kb-text-subtle);
+  background: var(--kb-surface);
+  padding: 16px 20px;
+  border-radius: var(--kb-radius-md);
+  box-shadow: var(--kb-shadow-soft);
+  border: 1px solid var(--kb-border);
+}
+
+#kb-loading::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 3px solid rgba(37, 99, 235, 0.25);
+  border-top-color: var(--kb-accent);
+  animation: kb-spin 0.9s linear infinite;
+}
+
+@keyframes kb-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.info-block {
+  background: var(--kb-surface);
+  border-radius: var(--kb-radius-lg);
+  padding: 40px;
+  box-shadow: var(--kb-shadow-soft);
+  display: grid;
+  gap: 20px;
+}
+
+.info-block h2 {
+  font-family: var(--kb-font-heading);
+  font-weight: 600;
+  font-size: 1.7rem;
+  margin: 0;
+}
+
+.info-block p,
+.info-block li {
+  color: var(--kb-text-subtle);
+  line-height: 1.7;
+}
+
+.info-block pre {
+  background: var(--kb-surface-soft);
+  border-radius: var(--kb-radius-md);
+  padding: 18px;
+  overflow-x: auto;
+  font-size: 0.95rem;
+  box-shadow: inset 0 0 0 1px var(--kb-border);
+}
+
+.info-block code {
+  font-family: 'JetBrains Mono', 'Fira Code', 'Source Code Pro', monospace;
+}
+
+.info-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.callout {
+  border-radius: var(--kb-radius-md);
+  background: var(--kb-surface-soft);
+  padding: 20px;
+  display: grid;
+  gap: 12px;
+  border: 1px solid var(--kb-border);
+}
+
+.callout strong {
+  font-size: 1rem;
+  color: var(--kb-text);
+}
+
+.kb-footer {
+  padding: 48px 0 64px;
+  background: transparent;
+  color: var(--kb-text-subtle);
+}
+
+.kb-footer .container {
+  width: min(1000px, 92vw);
+  margin: 0 auto;
+  display: grid;
+  gap: 12px;
+  justify-items: center;
+  text-align: center;
+  font-size: 0.95rem;
+}
+
+.kb-footer nav {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.kb-footer nav a {
+  color: inherit;
+  font-weight: 500;
+}
+
+/* Document page */
+
+main#doc-app {
+  width: min(780px, 92vw);
+  margin: 0 auto;
+  padding: 64px 0 96px;
+  display: grid;
+  gap: 48px;
+}
+
+.document-header {
+  background: var(--kb-surface);
+  padding: 40px;
+  border-radius: var(--kb-radius-lg);
+  box-shadow: var(--kb-shadow);
+  display: grid;
+  gap: 16px;
+}
+
+.document-header h1 {
+  font-family: var(--kb-font-heading);
+  font-weight: 700;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0;
+}
+
+.doc-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  color: var(--kb-text-subtle);
+  font-size: 0.95rem;
+}
+
+.doc-meta span:first-child {
+  background: var(--kb-tag-bg);
+  color: var(--kb-tag-text);
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.doc-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.doc-tags a {
+  background: var(--kb-tag-bg);
+  color: var(--kb-tag-text);
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+#doc-content {
+  background: var(--kb-surface);
+  border-radius: var(--kb-radius-lg);
+  padding: 48px;
+  box-shadow: var(--kb-shadow-soft);
+  line-height: 1.8;
+  font-size: 1.04rem;
+  color: var(--kb-text);
+}
+
+#doc-content h2,
+#doc-content h3,
+#doc-content h4 {
+  font-family: var(--kb-font-heading);
+  font-weight: 600;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  scroll-margin-top: 110px;
+}
+
+#doc-content h2 {
+  font-size: 1.7rem;
+}
+
+#doc-content h3 {
+  font-size: 1.35rem;
+}
+
+#doc-content p,
+#doc-content li {
+  color: var(--kb-text-subtle);
+}
+
+#doc-content code {
+  background: var(--kb-surface-soft);
+  padding: 0.2rem 0.5rem;
+  border-radius: 6px;
+  font-size: 0.95rem;
+}
+
+#doc-content pre code {
+  display: block;
+  padding: 1.2rem;
+  overflow-x: auto;
+  border-radius: var(--kb-radius-md);
+}
+
+#doc-content blockquote {
+  border-left: 4px solid var(--kb-accent);
+  padding-left: 1rem;
+  color: var(--kb-text);
+  background: rgba(37, 99, 235, 0.06);
+  border-radius: 0 12px 12px 0;
+}
+
+#doc-content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 2rem 0;
+  background: var(--kb-surface);
+}
+
+#doc-content table th,
+#doc-content table td {
+  border: 1px solid var(--kb-border);
+  padding: 12px 16px;
+  text-align: left;
+}
+
+.toc {
+  background: var(--kb-surface);
+  padding: 24px 32px;
+  border-radius: var(--kb-radius-lg);
+  box-shadow: var(--kb-shadow-soft);
+}
+
+.toc h2 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-top: 0;
+}
+
+.toc ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.toc li.nested {
+  margin-left: 1rem;
+  font-size: 0.95rem;
+}
+
+.toc ul ul {
+  padding-left: 18px;
+  border-left: 1px solid var(--kb-border);
+}
+
+.toc a {
+  color: var(--kb-text-subtle);
+  font-weight: 500;
+}
+
+.toc a:hover,
+.toc a:focus {
+  color: var(--kb-accent);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.return-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  color: var(--kb-accent);
+}
+
+.return-link svg {
+  width: 18px;
+  height: 18px;
+}
+
+.alert {
+  padding: 16px 20px;
+  border-radius: var(--kb-radius-md);
+  border: 1px solid var(--kb-border);
+  background: var(--kb-surface);
+  color: var(--kb-text-subtle);
+}
+
+.alert.error {
+  border-color: rgba(220, 38, 38, 0.35);
+  background: rgba(248, 113, 113, 0.12);
+  color: #b91c1c;
+}
+
+.alert.info {
+  border-color: rgba(59, 130, 246, 0.35);
+  background: rgba(96, 165, 250, 0.15);
+  color: var(--kb-accent-strong);
+}
+
+@media (max-width: 640px) {
+  .kb-header .container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .kb-nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero,
+  #doc-content,
+  .document-header {
+    padding: 32px 24px;
+  }
+
+  .hero-actions {
+    width: 100%;
+    flex-direction: column;
+  }
+
+  .hero-actions a {
+    width: 100%;
+    text-align: center;
+  }
+
+  main#doc-app {
+    padding-top: 48px;
+  }
+}

--- a/doc.html
+++ b/doc.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Knowledge Base Article</title>
+    <meta name="description" content="Read knowledge base articles published directly from Markdown files.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/knowledge-base.css">
+    <script defer src="js/kb-utils.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script defer src="js/doc-viewer.js"></script>
+  </head>
+  <body>
+    <header class="kb-header">
+      <div class="container">
+        <a class="brand" href="index.html">
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a4 4 0 0 1 2.828 1.172l6 6A4 4 0 0 1 22 12v7a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v-7a4 4 0 0 1 1.172-2.828l6-6A4 4 0 0 1 12 2Zm0 2a2 2 0 0 0-1.414.586l-6 6A2 2 0 0 0 4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7a2 2 0 0 0-.586-1.414l-6-6A2 2 0 0 0 12 4Z"/></svg>
+          <span>Knowledge Base</span>
+        </a>
+        <nav class="kb-nav" aria-label="Primary">
+          <a href="index.html#articles">Articles</a>
+          <a href="index.html#contribute">Contribute</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="doc-app" data-owner="Yxuan18" data-repo="Yxuan18.github.io" data-docs-path="docs">
+      <a class="return-link" href="index.html">
+        <svg aria-hidden="true" viewBox="0 0 20 20"><path fill="currentColor" d="M11.707 15.707a1 1 0 0 1-1.414 0l-5-5a1 1 0 0 1 0-1.414l5-5a1 1 0 0 1 1.414 1.414L7.414 10l4.293 4.293a1 1 0 0 1 0 1.414Z"/></svg>
+        Back to the knowledge base
+      </a>
+
+      <article>
+        <header class="document-header">
+          <h1 id="doc-title">Loading…</h1>
+          <div class="doc-meta">
+            <span id="doc-category"></span>
+            <span id="doc-updated" hidden></span>
+            <span id="doc-read-time"></span>
+          </div>
+          <div class="doc-tags" id="doc-tags"></div>
+        </header>
+
+        <nav class="toc" id="toc">
+          <h2>On this page</h2>
+        </nav>
+
+        <div id="doc-content">Loading article…</div>
+        <div id="doc-error" class="alert error" hidden role="alert"></div>
+      </article>
+    </main>
+
+    <footer class="kb-footer">
+      <div class="container">
+        <nav aria-label="Footer">
+          <a href="index.html#articles">Browse articles</a>
+          <a href="index.html#contribute">Contribute</a>
+          <a href="https://github.com/Yxuan18/Yxuan18.github.io" rel="noopener" target="_blank">View source</a>
+        </nav>
+        <p>Articles are published straight from Markdown files inside <code>docs/</code>.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/docs/configure-a-custom-domain.md
+++ b/docs/configure-a-custom-domain.md
@@ -1,0 +1,56 @@
+---
+title: Configure a Custom Domain
+description: Point your knowledge base to a memorable domain name using GitHub Pages or another static host.
+category: Operations
+tags: [deployment, dns, hosting]
+updated: 2024-02-02
+---
+
+You can share the knowledge base from the default GitHub Pages URL or attach a custom domain. The process takes only a few minutes and
+helps your team remember where to find documentation.
+
+## 1. Decide on your host
+
+The site works anywhere static files can be served. Common options include:
+
+- **GitHub Pages (default).** Ideal if this repository already publishes to `<username>.github.io`.
+- **Cloudflare Pages, Netlify, or Vercel.** Connect the repository and let the platform rebuild whenever you push changes.
+- **Self-hosted static server.** Copy the repository contents to your own infrastructure.
+
+The steps below assume you are using GitHub Pages, but the DNS configuration is similar elsewhere.
+
+## 2. Add a `CNAME` file
+
+Inside the repository root, create a file named `CNAME` containing your desired domain, for example:
+
+```
+docs.example.com
+```
+
+Commit and push the change. GitHub Pages reads this file to map the site to your domain.
+
+## 3. Update DNS records
+
+Add the following records with your DNS provider:
+
+| Type | Name | Value |
+| ---- | ---- | ----- |
+| CNAME | `docs` | `<username>.github.io` |
+| A | `@` | `185.199.108.153`, `185.199.109.153`, `185.199.110.153`, `185.199.111.153` |
+
+> If you are using an apex domain (for example `example.com`), create the four A records pointing to GitHub Pages. For a subdomain,
+> the CNAME record is sufficient.
+
+DNS changes may take up to an hour to propagate. You can check status with `dig docs.example.com +short`.
+
+## 4. Enforce HTTPS
+
+In your repository settings under **Pages**, enable “Enforce HTTPS” once the certificate becomes available. This ensures every article
+is delivered securely.
+
+## 5. Test the site
+
+Visit the new domain and browse a few articles. If you see a 404 or certificate warning, wait a few more minutes or double-check the DNS
+configuration. You can always fall back to the default GitHub Pages URL while DNS propagates.
+
+With the domain live, share it with your team and bookmark it for quick reference.

--- a/docs/how-to-add-content.md
+++ b/docs/how-to-add-content.md
@@ -1,0 +1,61 @@
+---
+title: Publish a New Article
+description: Step-by-step instructions for writing, reviewing, and deploying Markdown content to the knowledge base.
+category: Maintain
+tags: [contributing, markdown, workflow]
+updated: 2024-02-01
+---
+
+Follow this checklist whenever you want to add or update an article.
+
+## 1. Create your Markdown file
+
+1. Open the repository locally or within the GitHub web editor.
+2. Add a new file inside the `docs/` directory. Use lowercase, hyphenated file names (for example, `setting-up-sso.md`).
+3. If you want to group topics, place the file in a sub-folder: `docs/onboarding/creating-accounts.md`.
+
+## 2. Add front matter metadata
+
+Each article starts with a block between two sets of `---`. This metadata powers the site UI, so keep it accurate:
+
+```yaml
+---
+title: Setting up single sign-on
+description: Connect the product to your identity provider in under ten minutes.
+category: Operations
+tags: [authentication, how-to]
+updated: 2024-02-01
+---
+```
+
+- `title` becomes the article heading.
+- `description` appears as the summary on the home page.
+- `category` groups related articles.
+- `tags` enable tag-based filtering. Use simple, lowercase keywords.
+- `updated` should reflect the last significant edit.
+- Optional: add `draft: true` to hide the file until it is ready to publish.
+
+## 3. Write the body
+
+Use plain Markdown. The viewer supports headings (`#` through `####`), lists, tables, code blocks, callouts, and links. Stick to
+sentence-case headings and keep paragraphs short for readability.
+
+### Embedding media
+
+- **Images:** store static assets alongside the article (`docs/images/...`) and reference them with relative paths.
+- **Diagrams:** export diagrams as PNG or SVG before embedding.
+- **Videos:** link out to the hosted video rather than embedding large files in the repository.
+
+## 4. Review and commit
+
+1. Preview the Markdown locally (for example, with VS Code) to ensure formatting looks correct.
+2. Run spelling or linting tools if your project uses them.
+3. Commit the new file and any assets with a descriptive message.
+
+If you work on a team, open a pull request so someone else can review the changes. Once merged into the default branch, GitHub Pages
+(or your hosting provider) redeploys automatically. Refresh the site after the build completes to see the new article listed.
+
+## 5. Keep content fresh
+
+Schedule regular reviews for critical content. At minimum, glance over high-traffic articles quarterly to confirm instructions are still
+accurate. Update the `updated` field whenever the material changes so readers know it is current.

--- a/docs/troubleshoot-deployments.md
+++ b/docs/troubleshoot-deployments.md
@@ -1,0 +1,53 @@
+---
+title: Troubleshoot Deployments
+description: Diagnose why new Markdown articles are not appearing or updates are missing from the live site.
+category: Support
+tags: [troubleshooting, deployment]
+updated: 2024-02-03
+---
+
+If a newly published article is missing or content looks out of date, work through the checks below.
+
+## 1. Confirm the file path
+
+- The file must live somewhere under the `docs/` directory.
+- Ensure the filename ends in `.md`.
+- If you renamed or moved a file, confirm there are no leftover uppercase letters or spaces in the path.
+
+## 2. Validate the front matter
+
+The site ignores articles marked as drafts. Make sure the top of the file looks similar to the following:
+
+```yaml
+---
+title: Example article
+description: Short summary.
+category: Start Here
+tags: [example]
+updated: 2024-02-03
+---
+```
+
+If the metadata block is missing, malformed, or contains `draft: true`, the article will be skipped.
+
+## 3. Check the deployment logs
+
+- For GitHub Pages, open the repository → **Actions** → **Pages build and deployment** to inspect recent runs.
+- Look for red ❌ icons indicating a failure. Click through to view error details.
+- Fix any build errors (for example, merge conflicts, missing files) and push a new commit to trigger another deployment.
+
+## 4. Bypass the cache
+
+Sometimes browsers cache the homepage. Perform a hard refresh or open the site in an incognito/private window. If you use a CDN,
+invalidate the cache for the `index.html` and `doc.html` files.
+
+## 5. Verify API rate limits
+
+The article list relies on the GitHub API. If you reload the homepage dozens of times in a short period while unauthenticated, you
+might hit the rate limit (60 requests per hour). Wait a few minutes, or sign in to GitHub in the same browser session to increase the
+limit.
+
+## 6. Still stuck?
+
+Capture the console output from your browser’s developer tools and open an issue in the repository. Include details about the file you
+added, the URL you expected to load, and any error messages displayed in the UI.

--- a/docs/welcome-to-your-knowledge-base.md
+++ b/docs/welcome-to-your-knowledge-base.md
@@ -1,0 +1,40 @@
+---
+title: Welcome to Your Knowledge Base
+description: Get a guided tour of the Markdown-driven portal and learn how everything fits together.
+category: Start Here
+tags: [overview, orientation]
+updated: 2024-02-01
+---
+
+Your knowledge base is ready to publish the moment you merge a Markdown file into the repository. This welcome guide highlights the
+core experience and shows how to help teammates find the answers they need.
+
+## What lives here?
+
+The site automatically indexes every Markdown document stored inside the `docs/` directory. Articles are grouped by category, tagged for
+search, and listed on the home page with a short summary. Because the content lives alongside your code, you can review, version, and
+audit every change without leaving your normal workflow.
+
+## Navigating the site
+
+1. **Home page.** The landing page surfaces search, popular tags, and key onboarding information so visitors can quickly locate the
+   right resource.
+2. **Search & filters.** Type a keyword to filter results instantly, or click a tag to narrow the list to a specific topic.
+3. **Article view.** Each article displays metadata, reading time, and a dynamic table of contents generated from headings.
+
+> Tip: Use descriptive titles and headings in your Markdown files—the site converts them into navigation anchors automatically.
+
+## Recommended conventions
+
+- **Keep descriptions concise.** A one or two sentence summary in the front matter gives readers context before they click.
+- **Use categories intentionally.** Think in terms of the questions visitors ask (for example, *Start Here*, *How-To*, *Operations*).
+- **Leverage tags.** Tags make it easy to group related content across categories. Aim for one to five per article.
+- **Document ownership.** Add a section at the end of each article noting who maintains it and how to request updates.
+
+## Beyond the basics
+
+Need custom behaviour? Extend the repository just like any static site. You can add analytics, integrate a feedback form, or embed
+videos—all while keeping authoring as simple as committing Markdown. If you want to personalise the theme, adjust `css/knowledge-base.css`
+and commit the changes.
+
+Ready to share more? Head over to the contributor guide to publish your first article.

--- a/index.html
+++ b/index.html
@@ -1,228 +1,139 @@
 <!DOCTYPE html>
-<html>
-<head><meta name="generator" content="Hexo 3.9.0">
-  <meta charset="utf-8">
-  
-
-  
-  <title>Hexo</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-  <meta property="og:type" content="website">
-<meta property="og:title" content="Hexo">
-<meta property="og:url" content="http://yoursite.com/index.html">
-<meta property="og:site_name" content="Hexo">
-<meta property="og:locale" content="default">
-<meta name="twitter:card" content="summary">
-<meta name="twitter:title" content="Hexo">
-  
-    <link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">
-  
-  
-    <link rel="icon" href="/favicon.png">
-  
-  
-    <link href="//fonts.googleapis.com/css?family=Source+Code+Pro" rel="stylesheet" type="text/css">
-  
-  <link rel="stylesheet" href="/css/style.css">
-</head>
-</html>
-<body>
-  <div id="container">
-    <div id="wrap">
-      <header id="header">
-  <div id="banner"></div>
-  <div id="header-outer" class="outer">
-    <div id="header-title" class="inner">
-      <h1 id="logo-wrap">
-        <a href="/" id="logo">Hexo</a>
-      </h1>
-      
-    </div>
-    <div id="header-inner" class="inner">
-      <nav id="main-nav">
-        <a id="main-nav-toggle" class="nav-icon"></a>
-        
-          <a class="main-nav-link" href="/">Home</a>
-        
-          <a class="main-nav-link" href="/archives">Archives</a>
-        
-      </nav>
-      <nav id="sub-nav">
-        
-          <a id="nav-rss-link" class="nav-icon" href="/atom.xml" title="RSS Feed"></a>
-        
-        <a id="nav-search-btn" class="nav-icon" title="Search"></a>
-      </nav>
-      <div id="search-form-wrap">
-        <form action="//google.com/search" method="get" accept-charset="UTF-8" class="search-form"><input type="search" name="q" class="search-form-input" placeholder="Search"><button type="submit" class="search-form-submit">&#xF002;</button><input type="hidden" name="sitesearch" value="http://yoursite.com"></form>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Knowledge Base | Markdown-powered help centre</title>
+    <meta name="description" content="Publish Markdown files to power a beautiful, searchable knowledge base without leaving your repository.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Poppins:wght@600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/knowledge-base.css">
+    <script defer src="js/kb-utils.js"></script>
+    <script defer src="js/knowledge-base.js"></script>
+  </head>
+  <body>
+    <header class="kb-header">
+      <div class="container">
+        <a class="brand" href="/">
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path fill="currentColor" d="M12 2a4 4 0 0 1 2.828 1.172l6 6A4 4 0 0 1 22 12v7a3 3 0 0 1-3 3H5a3 3 0 0 1-3-3v-7a4 4 0 0 1 1.172-2.828l6-6A4 4 0 0 1 12 2Zm0 2a2 2 0 0 0-1.414.586l-6 6A2 2 0 0 0 4 12v7a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1v-7a2 2 0 0 0-.586-1.414l-6-6A2 2 0 0 0 12 4Z"/></svg>
+          <span>Knowledge Base</span>
+        </a>
+        <nav class="kb-nav" aria-label="Primary">
+          <a href="#top">Overview</a>
+          <a href="#articles">Articles</a>
+          <a href="#contribute">Contribute</a>
+        </nav>
       </div>
-    </div>
-  </div>
-</header>
-      <div class="outer">
-        <section id="main">
-  
-    <article id="post-test-my-site" class="article article-type-post" itemscope itemprop="blogPost">
-  <div class="article-meta">
-    <a href="/2019/08/06/test-my-site/" class="article-date">
-  <time datetime="2019-08-06T01:55:43.000Z" itemprop="datePublished">2019-08-06</time>
-</a>
-    
-  </div>
-  <div class="article-inner">
-    
-    
-      <header class="article-header">
-        
-  
-    <h1 itemprop="name">
-      <a class="article-title" href="/2019/08/06/test-my-site/">test_my_site</a>
-    </h1>
-  
+    </header>
 
-      </header>
-    
-    <div class="article-entry" itemprop="articleBody">
-      
-        
-      
-    </div>
-    <footer class="article-footer">
-      <a data-url="http://yoursite.com/2019/08/06/test-my-site/" data-id="cjyz6yuu60000fovw4bkdigsi" class="article-share-link">Share</a>
-      
-      
-    </footer>
-  </div>
-  
-</article>
+    <main id="kb-app" data-owner="Yxuan18" data-repo="Yxuan18.github.io" data-docs-path="docs">
+      <section class="hero" id="top">
+        <h1>Ship your knowledge base in minutes</h1>
+        <p>
+          Drop Markdown files into the <code>docs/</code> folder and they are instantly available on the web. Search, filter, and share
+          everything your team needs to know from a single, elegant hub.
+        </p>
+        <div class="hero-actions">
+          <a class="primary" href="#articles">Browse articles</a>
+          <a class="secondary" href="#contribute">Publish a new article</a>
+        </div>
+        <div class="quick-stats" aria-label="Knowledge base highlights">
+          <div class="stat">
+            <strong id="article-count">0</strong>
+            <span>Published articles</span>
+          </div>
+          <div class="stat">
+            <strong>Markdown first</strong>
+            <span>Author content locally and push to deploy automatically.</span>
+          </div>
+          <div class="stat">
+            <strong>Always searchable</strong>
+            <span>Filter by keywords, categories, and reusable tags.</span>
+          </div>
+        </div>
+      </section>
 
+      <section class="tools" aria-label="Knowledge base filters and tools">
+        <div class="search-bar">
+          <label for="kb-search">Search the knowledge base</label>
+          <svg aria-hidden="true" viewBox="0 0 24 24"><path fill="currentColor" d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 1 0-.71.71l.27.28v.79l5 4.99L20.49 19l-4.99-5Zm-6 0a4.5 4.5 0 1 1 0-9 4.5 4.5 0 0 1 0 9Z"/></svg>
+          <input type="search" id="kb-search" name="search" placeholder="Search by title, topic, or keyword" autocomplete="off">
+        </div>
+        <p id="result-count" class="result-count" aria-live="polite"></p>
+        <div id="active-filters" class="active-filters" hidden aria-live="polite"></div>
+        <div>
+          <h2 class="visually-hidden">Popular tags</h2>
+          <div id="tag-cloud" class="tag-cloud" aria-label="Tag filters"></div>
+        </div>
+      </section>
 
-  
-    <article id="post-hello-world" class="article article-type-post" itemscope itemprop="blogPost">
-  <div class="article-meta">
-    <a href="/2019/08/06/hello-world/" class="article-date">
-  <time datetime="2019-08-06T01:42:01.009Z" itemprop="datePublished">2019-08-06</time>
-</a>
-    
-  </div>
-  <div class="article-inner">
-    
-    
-      <header class="article-header">
-        
-  
-    <h1 itemprop="name">
-      <a class="article-title" href="/2019/08/06/hello-world/">Hello World</a>
-    </h1>
-  
+      <section id="articles" aria-label="Knowledge base articles">
+        <div id="kb-loading" role="status">Loading articles…</div>
+        <div id="article-list" class="card-grid" hidden aria-live="polite"></div>
+        <div id="empty-state" class="empty-state" hidden>
+          <h2>Publish your first article</h2>
+          <p>Every Markdown file you add to <code>docs/</code> appears here automatically. Use the template below to get started.</p>
+        </div>
+        <div id="error-state" class="alert error" hidden role="alert"></div>
+      </section>
 
-      </header>
-    
-    <div class="article-entry" itemprop="articleBody">
-      
-        <p>Welcome to <a href="https://hexo.io/" target="_blank" rel="noopener">Hexo</a>! This is your very first post. Check <a href="https://hexo.io/docs/" target="_blank" rel="noopener">documentation</a> for more info. If you get any problems when using Hexo, you can find the answer in <a href="https://hexo.io/docs/troubleshooting.html" target="_blank" rel="noopener">troubleshooting</a> or you can ask me on <a href="https://github.com/hexojs/hexo/issues" target="_blank" rel="noopener">GitHub</a>.</p>
-<h2 id="Quick-Start"><a href="#Quick-Start" class="headerlink" title="Quick Start"></a>Quick Start</h2><h3 id="Create-a-new-post"><a href="#Create-a-new-post" class="headerlink" title="Create a new post"></a>Create a new post</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo new <span class="string">"My New Post"</span></span><br></pre></td></tr></table></figure>
+      <section id="contribute" class="info-block" aria-labelledby="contribute-heading">
+        <h2 id="contribute-heading">Publish with Markdown</h2>
+        <p>
+          Keep your workflow simple. Write in Markdown, commit to the repository, and GitHub Pages (or any static host) takes care of the
+          rest. Front matter at the top of each file powers search, filters, and article metadata.
+        </p>
+        <div class="info-grid">
+          <div class="callout">
+            <strong>1. Create a markdown file</strong>
+            <p>Name it descriptively, like <code>incident-response.md</code>.</p>
+          </div>
+          <div class="callout">
+            <strong>2. Add helpful metadata</strong>
+            <p>Include title, description, tags, and a category so the site can organise it.</p>
+          </div>
+          <div class="callout">
+            <strong>3. Commit and push</strong>
+            <p>Once the file lands on the default branch, the knowledge base updates automatically.</p>
+          </div>
+        </div>
+        <pre><code>---
+title: Example Article
+description: One sentence summary of the article.
+category: Operations
+tags: [how-to, onboarding]
+updated: 2024-02-01
+---
 
-<p>More info: <a href="https://hexo.io/docs/writing.html" target="_blank" rel="noopener">Writing</a></p>
-<h3 id="Run-server"><a href="#Run-server" class="headerlink" title="Run server"></a>Run server</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo server</span><br></pre></td></tr></table></figure>
+Write the rest of your article in Markdown. Use headings, lists, code blocks, and images just like any README.</code></pre>
+        <p>
+          Need to hide a draft? Add <code>draft: true</code> to the front matter. You can also organise content into sub-folders inside
+          <code>docs/</code>; everything is indexed recursively.
+        </p>
+      </section>
 
-<p>More info: <a href="https://hexo.io/docs/server.html" target="_blank" rel="noopener">Server</a></p>
-<h3 id="Generate-static-files"><a href="#Generate-static-files" class="headerlink" title="Generate static files"></a>Generate static files</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo generate</span><br></pre></td></tr></table></figure>
+      <section id="faq" class="info-block" aria-labelledby="faq-heading">
+        <h2 id="faq-heading">Frequently asked questions</h2>
+        <ul>
+          <li><strong>Where are the articles stored?</strong> Every markdown file lives in the <code>docs/</code> directory of this repository.</li>
+          <li><strong>How do I share it?</strong> Point your custom domain at GitHub Pages or share <code>https://yxuan18.github.io</code>.</li>
+          <li><strong>Can I nest content?</strong> Yes. Place markdown files in sub-folders under <code>docs/</code>; they will still be indexed.</li>
+          <li><strong>Can I use another host?</strong> Absolutely. Any static hosting service that serves this repository works.</li>
+        </ul>
+      </section>
+    </main>
 
-<p>More info: <a href="https://hexo.io/docs/generating.html" target="_blank" rel="noopener">Generating</a></p>
-<h3 id="Deploy-to-remote-sites"><a href="#Deploy-to-remote-sites" class="headerlink" title="Deploy to remote sites"></a>Deploy to remote sites</h3><figure class="highlight bash"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><span class="line">$ hexo deploy</span><br></pre></td></tr></table></figure>
-
-<p>More info: <a href="https://hexo.io/docs/deployment.html" target="_blank" rel="noopener">Deployment</a></p>
-
-      
-    </div>
-    <footer class="article-footer">
-      <a data-url="http://yoursite.com/2019/08/06/hello-world/" data-id="cjyz6yuur0001fovwg0nu0dew" class="article-share-link">Share</a>
-      
-      
-    </footer>
-  </div>
-  
-</article>
-
-
-  
-
-
-</section>
-        
-          <aside id="sidebar">
-  
-    
-
-  
-    
-
-  
-    
-  
-    
-  <div class="widget-wrap">
-    <h3 class="widget-title">Archives</h3>
-    <div class="widget">
-      <ul class="archive-list"><li class="archive-list-item"><a class="archive-list-link" href="/archives/2019/08/">August 2019</a></li></ul>
-    </div>
-  </div>
-
-
-  
-    
-  <div class="widget-wrap">
-    <h3 class="widget-title">Recent Posts</h3>
-    <div class="widget">
-      <ul>
-        
-          <li>
-            <a href="/2019/08/06/test-my-site/">test_my_site</a>
-          </li>
-        
-          <li>
-            <a href="/2019/08/06/hello-world/">Hello World</a>
-          </li>
-        
-      </ul>
-    </div>
-  </div>
-
-  
-</aside>
-        
+    <footer class="kb-footer">
+      <div class="container">
+        <nav aria-label="Footer">
+          <a href="#top">Back to top</a>
+          <a href="doc.html?doc=docs/how-to-add-content.md">Contributor guide</a>
+          <a href="https://github.com/Yxuan18/Yxuan18.github.io" rel="noopener" target="_blank">View source</a>
+        </nav>
+        <p>Built for Markdown-first teams. Deploy anywhere a static site can live.</p>
       </div>
-      <footer id="footer">
-  
-  <div class="outer">
-    <div id="footer-info" class="inner">
-      &copy; 2019 John Doe<br>
-      Powered by <a href="http://hexo.io/" target="_blank">Hexo</a>
-    </div>
-  </div>
-</footer>
-    </div>
-    <nav id="mobile-nav">
-  
-    <a href="/" class="mobile-nav-link">Home</a>
-  
-    <a href="/archives" class="mobile-nav-link">Archives</a>
-  
-</nav>
-    
-
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery.min.js"></script>
-
-
-  <link rel="stylesheet" href="/fancybox/jquery.fancybox.css">
-  <script src="/fancybox/jquery.fancybox.pack.js"></script>
-
-
-<script src="/js/script.js"></script>
-
-
-
-  </div>
-</body>
+    </footer>
+  </body>
 </html>

--- a/js/doc-viewer.js
+++ b/js/doc-viewer.js
@@ -1,0 +1,175 @@
+(function (window, document, KB) {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const app = document.getElementById('doc-app');
+    if (!app) {
+      return;
+    }
+
+    let context;
+    try {
+      context = KB.normalizeContext(app);
+    } catch (error) {
+      console.error(error);
+      renderFatalError(error.message);
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+    const docParam = params.get('doc');
+    if (!docParam) {
+      renderFatalError('No article was specified. Please access this page from the knowledge base.');
+      return;
+    }
+
+    const docPath = decodeURIComponent(docParam).replace(/^\/+/, '');
+
+    const titleEl = document.getElementById('doc-title');
+    const categoryEl = document.getElementById('doc-category');
+    const updatedEl = document.getElementById('doc-updated');
+    const readTimeEl = document.getElementById('doc-read-time');
+    const tagsEl = document.getElementById('doc-tags');
+    const contentEl = document.getElementById('doc-content');
+    const tocEl = document.getElementById('toc');
+    const errorEl = document.getElementById('doc-error');
+
+    loadDocument().catch(error => {
+      console.error(error);
+      showError(error.message || 'Unable to load the requested article.');
+    });
+
+    async function loadDocument() {
+      const branch = await KB.getDefaultBranch(context);
+      const markdown = await KB.fetchMarkdown(context, branch, docPath);
+      const parsed = KB.parseFrontMatter(markdown);
+
+      if (KB.isDraft(parsed.data)) {
+        throw new Error('This article is marked as draft and is not published yet.');
+      }
+
+      const title = parsed.data.title || KB.slugToTitle(docPath);
+      const category = parsed.data.category || parsed.data.section || 'General';
+      const tags = KB.normalizeTags(parsed.data.tags);
+      const updated = parsed.data.updated || parsed.data.lastUpdated || parsed.data.date || null;
+      const readTime = KB.estimateReadTime(parsed.content);
+
+      if (titleEl) {
+        titleEl.textContent = title;
+      }
+      document.title = `${title} · Knowledge Base`;
+
+      if (categoryEl) {
+        categoryEl.textContent = category;
+      }
+
+      if (updatedEl && updated) {
+        updatedEl.textContent = `Updated ${KB.formatDate(updated)}`;
+        updatedEl.hidden = false;
+      }
+
+      if (readTimeEl) {
+        readTimeEl.textContent = `${readTime} min read`;
+      }
+
+      if (tagsEl) {
+        tagsEl.innerHTML = '';
+        if (tags.length) {
+          tags.forEach(tag => {
+            const link = document.createElement('a');
+            link.href = `index.html?tag=${encodeURIComponent(tag.toLowerCase())}`;
+            link.textContent = tag;
+            tagsEl.appendChild(link);
+          });
+        } else {
+          tagsEl.hidden = true;
+        }
+      }
+
+      if (!window.marked) {
+        throw new Error('Markdown renderer not found. Please ensure marked.js is loaded.');
+      }
+
+      const html = window.marked.parse(parsed.content);
+      contentEl.innerHTML = html;
+
+      enhanceContent(contentEl);
+      buildToc(contentEl, tocEl);
+    }
+
+    function enhanceContent(container) {
+      if (!container) {
+        return;
+      }
+
+      container.querySelectorAll('a[href^="http"]').forEach(anchor => {
+        anchor.setAttribute('target', '_blank');
+        anchor.setAttribute('rel', 'noopener');
+      });
+    }
+
+    function buildToc(container, tocContainer) {
+      if (!container || !tocContainer) {
+        return;
+      }
+
+      const headings = Array.from(container.querySelectorAll('h2, h3'));
+      if (!headings.length) {
+        tocContainer.hidden = true;
+        return;
+      }
+
+      const list = document.createElement('ul');
+      const slugCounts = new Map();
+
+      headings.forEach(heading => {
+        const level = Number(heading.tagName.replace('H', ''));
+        const slug = createHeadingSlug(heading.textContent, slugCounts);
+        heading.id = heading.id || slug;
+
+        const item = document.createElement('li');
+        if (level === 3) {
+          item.className = 'nested';
+        }
+
+        const link = document.createElement('a');
+        link.href = `#${heading.id}`;
+        link.textContent = heading.textContent;
+        item.appendChild(link);
+        list.appendChild(item);
+      });
+
+      tocContainer.hidden = false;
+      tocContainer.querySelector('ul')?.remove();
+      tocContainer.appendChild(list);
+    }
+
+    function createHeadingSlug(text, slugCounts) {
+      const baseSlug = text
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-');
+      const current = slugCounts.get(baseSlug) || 0;
+      slugCounts.set(baseSlug, current + 1);
+      return current ? `${baseSlug}-${current}` : baseSlug || `section-${slugCounts.size + 1}`;
+    }
+
+    function showError(message) {
+      if (!errorEl) {
+        alert(message);
+        return;
+      }
+      errorEl.hidden = false;
+      errorEl.textContent = message;
+    }
+
+    function renderFatalError(message) {
+      const fatalContainer = document.createElement('div');
+      fatalContainer.className = 'alert error';
+      fatalContainer.textContent = message;
+      app.innerHTML = '';
+      app.appendChild(fatalContainer);
+    }
+  });
+})(window, document, window.KB || {});

--- a/js/kb-utils.js
+++ b/js/kb-utils.js
@@ -1,0 +1,299 @@
+(function (window) {
+  'use strict';
+
+  const KB = {
+    cache: {
+      branch: null,
+      repoInfo: null,
+      trees: new Map()
+    }
+  };
+
+  function normalizeContext(el) {
+    if (!el) {
+      throw new Error('Knowledge base root element not found.');
+    }
+
+    const owner = el.dataset.owner || '';
+    const repo = el.dataset.repo || '';
+    if (!owner || !repo) {
+      throw new Error('Knowledge base configuration is missing the repository owner or name.');
+    }
+
+    return {
+      owner,
+      repo,
+      docsPath: el.dataset.docsPath || 'docs',
+      branch: el.dataset.branch || null,
+      offline: el.dataset.offline === 'true',
+      cache: {
+        branch: null,
+        tree: null
+      }
+    };
+  }
+
+  function buildApiBase(context) {
+    return `https://api.github.com/repos/${context.owner}/${context.repo}`;
+  }
+
+  function buildRawBase(context) {
+    return `https://raw.githubusercontent.com/${context.owner}/${context.repo}`;
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url, {
+      headers: {
+        'Accept': 'application/vnd.github+json'
+      }
+    });
+
+    if (!response.ok) {
+      const error = new Error(`Request failed with status ${response.status}`);
+      error.status = response.status;
+      error.url = url;
+      throw error;
+    }
+
+    return response.json();
+  }
+
+  async function getDefaultBranch(context) {
+    if (context.branch) {
+      return context.branch;
+    }
+
+    if (context.cache.branch) {
+      return context.cache.branch;
+    }
+
+    if (KB.cache.branch && KB.cache.repoInfo && KB.cache.repoInfo.owner === context.owner && KB.cache.repoInfo.repo === context.repo) {
+      return KB.cache.branch;
+    }
+
+    const apiBase = buildApiBase(context);
+    const data = await fetchJson(apiBase);
+    const branch = data.default_branch || 'main';
+
+    KB.cache.repoInfo = { owner: context.owner, repo: context.repo };
+    KB.cache.branch = branch;
+    context.cache.branch = branch;
+
+    return branch;
+  }
+
+  async function getTree(context, branch) {
+    const cacheKey = `${context.owner}/${context.repo}#${branch}`;
+    if (context.cache.tree) {
+      return context.cache.tree;
+    }
+
+    if (KB.cache.trees.has(cacheKey)) {
+      return KB.cache.trees.get(cacheKey);
+    }
+
+    const apiBase = buildApiBase(context);
+    const treeUrl = `${apiBase}/git/trees/${encodeURIComponent(branch)}?recursive=1`;
+    const data = await fetchJson(treeUrl);
+    if (!data.tree) {
+      throw new Error('The Git tree response did not include any file information.');
+    }
+
+    KB.cache.trees.set(cacheKey, data.tree);
+    context.cache.tree = data.tree;
+
+    return data.tree;
+  }
+
+  function buildRawUrl(context, branch, path) {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/');
+    return `${buildRawBase(context)}/${encodeURIComponent(branch)}/${encodedPath}`;
+  }
+
+  async function fetchMarkdown(context, branch, path) {
+    const rawUrl = buildRawUrl(context, branch, path);
+
+    try {
+      const response = await fetch(rawUrl, { cache: 'no-store' });
+      if (response.ok) {
+        return await response.text();
+      }
+    } catch (error) {
+      console.warn('Falling back to same-origin fetch for', path, error);
+    }
+
+    const fallback = path.startsWith('/') ? path : `/${path}`;
+    try {
+      const response = await fetch(fallback, { cache: 'no-store' });
+      if (response.ok) {
+        return await response.text();
+      }
+    } catch (fallbackError) {
+      console.warn('Fallback fetch failed for', path, fallbackError);
+    }
+
+    throw new Error(`Unable to load markdown file at ${path}`);
+  }
+
+  function parseFrontMatter(markdown) {
+    if (!markdown.startsWith('---')) {
+      return { data: {}, content: markdown.trim() };
+    }
+
+    const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?/);
+    if (!match) {
+      return { data: {}, content: markdown.trim() };
+    }
+
+    const yaml = match[1];
+    const rest = markdown.slice(match[0].length);
+    const data = parseYaml(yaml);
+
+    return { data, content: rest.trim() };
+  }
+
+  function parseYaml(block) {
+    const lines = block.split(/\r?\n/);
+    const result = {};
+    let currentArrayKey = null;
+
+    for (const rawLine of lines) {
+      const line = rawLine.trimEnd();
+      if (!line.trim()) {
+        continue;
+      }
+
+      const arrayItemMatch = line.match(/^-(.+)$/);
+      if (arrayItemMatch && currentArrayKey && Array.isArray(result[currentArrayKey])) {
+        result[currentArrayKey].push(cleanValue(arrayItemMatch[1].trim()));
+        continue;
+      }
+
+      const kvMatch = line.match(/^([A-Za-z0-9_\- ]+):\s*(.*)$/);
+      if (!kvMatch) {
+        continue;
+      }
+
+      const key = kvMatch[1].trim();
+      const value = kvMatch[2].trim();
+
+      if (!value) {
+        result[key] = [];
+        currentArrayKey = key;
+        continue;
+      }
+
+      if (value.startsWith('[') && value.endsWith(']')) {
+        const inner = value.slice(1, -1).trim();
+        result[key] = inner ? inner.split(',').map(item => cleanValue(item.trim())).filter(Boolean) : [];
+        currentArrayKey = key;
+        continue;
+      }
+
+      result[key] = cleanValue(value);
+      currentArrayKey = key;
+    }
+
+    return result;
+  }
+
+  function cleanValue(value) {
+    if (value === 'true' || value === 'false') {
+      return value === 'true';
+    }
+
+    const numeric = Number(value);
+    if (!Number.isNaN(numeric) && value !== '') {
+      return numeric;
+    }
+
+    return value.replace(/^['"]|['"]$/g, '');
+  }
+
+  function createExcerpt(text, length = 200) {
+    const withoutCode = text.replace(/```[\s\S]*?```/g, ' ');
+    const withoutInlineCode = withoutCode.replace(/`[^`]*`/g, ' ');
+    const withoutLinks = withoutInlineCode.replace(/!\[[^\]]*\]\([^)]*\)/g, ' ').replace(/\[[^\]]*\]\([^)]*\)/g, '$1');
+    const stripped = withoutLinks.replace(/[#>*_~]/g, ' ').replace(/\s+/g, ' ').trim();
+
+    if (stripped.length <= length) {
+      return stripped;
+    }
+
+    return `${stripped.slice(0, length).trimEnd()}…`;
+  }
+
+  function estimateReadTime(text) {
+    const words = text.trim().split(/\s+/).filter(Boolean).length;
+    return Math.max(1, Math.round(words / 200));
+  }
+
+  function formatDate(value) {
+    if (!value) {
+      return null;
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+      return null;
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    }).format(date);
+  }
+
+  function slugToTitle(path) {
+    const base = path.split('/').pop() || path;
+    const withoutExt = base.replace(/\.md$/i, '');
+    return withoutExt
+      .split(/[-_]/g)
+      .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ');
+  }
+
+  function normalizeTags(tags) {
+    if (!tags) {
+      return [];
+    }
+    if (Array.isArray(tags)) {
+      return tags.map(tag => String(tag)).filter(Boolean);
+    }
+    if (typeof tags === 'string') {
+      return tags.split(',').map(tag => tag.trim()).filter(Boolean);
+    }
+    return [];
+  }
+
+  function isDraft(meta = {}) {
+    if (meta.draft === true) {
+      return true;
+    }
+    if (typeof meta.draft === 'string') {
+      return meta.draft.toLowerCase() === 'true';
+    }
+    if (meta.published === false) {
+      return true;
+    }
+    if (typeof meta.status === 'string' && meta.status.toLowerCase() === 'draft') {
+      return true;
+    }
+    return false;
+  }
+
+  window.KB = Object.assign(KB, {
+    normalizeContext,
+    getDefaultBranch,
+    getTree,
+    fetchMarkdown,
+    parseFrontMatter,
+    createExcerpt,
+    estimateReadTime,
+    formatDate,
+    slugToTitle,
+    normalizeTags,
+    isDraft
+  });
+})(window);

--- a/js/knowledge-base.js
+++ b/js/knowledge-base.js
@@ -1,0 +1,388 @@
+(function (window, document, KB) {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const app = document.getElementById('kb-app');
+    if (!app) {
+      return;
+    }
+
+    let context;
+    try {
+      context = KB.normalizeContext(app);
+    } catch (error) {
+      console.error(error);
+      renderFatalError(error.message);
+      return;
+    }
+
+    const searchInput = document.getElementById('kb-search');
+    const listContainer = document.getElementById('article-list');
+    const loadingIndicator = document.getElementById('kb-loading');
+    const emptyState = document.getElementById('empty-state');
+    const errorState = document.getElementById('error-state');
+    const tagCloud = document.getElementById('tag-cloud');
+    const activeFilters = document.getElementById('active-filters');
+    const articleCount = document.getElementById('article-count');
+    const resultCount = document.getElementById('result-count');
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const initialQuery = urlParams.get('q') || '';
+    const initialTagParam = urlParams.get('tags') || urlParams.get('tag') || '';
+    const initialTags = initialTagParam
+      .split(',')
+      .map(tag => tag.trim().toLowerCase())
+      .filter(Boolean);
+
+    const state = {
+      docs: [],
+      query: initialQuery,
+      activeTags: new Set(initialTags),
+      branch: null
+    };
+
+    if (searchInput) {
+      searchInput.value = initialQuery;
+      searchInput.addEventListener('input', event => {
+        state.query = event.target.value.trim();
+        applyFilters();
+      });
+    }
+
+    init().catch(error => {
+      console.error(error);
+      showError(error.message || 'Unable to load knowledge base content.');
+    });
+
+    async function init() {
+      showLoading(true);
+      const branch = await KB.getDefaultBranch(context);
+      state.branch = branch;
+      const docs = await loadDocuments(branch);
+      state.docs = docs;
+      updateArticleCount(docs.length);
+      buildTagCloud(docs);
+      applyFilters();
+      showLoading(false);
+    }
+
+    async function loadDocuments(branch) {
+      const tree = await KB.getTree(context, branch);
+      const docsPath = context.docsPath.replace(/\/+$/, '') + '/';
+      const matches = tree.filter(item => item.type === 'blob' && item.path.startsWith(docsPath) && item.path.toLowerCase().endsWith('.md'));
+
+      if (!matches.length) {
+        return [];
+      }
+
+      const documents = [];
+      for (const entry of matches) {
+        try {
+          const markdown = await KB.fetchMarkdown(context, branch, entry.path);
+          const parsed = KB.parseFrontMatter(markdown);
+          if (KB.isDraft(parsed.data)) {
+            continue;
+          }
+
+          const title = parsed.data.title || KB.slugToTitle(entry.path);
+          const description = parsed.data.description || KB.createExcerpt(parsed.content, 220);
+          const tags = KB.normalizeTags(parsed.data.tags);
+          const category = parsed.data.category || parsed.data.section || 'General';
+          const updated = parsed.data.updated || parsed.data.lastUpdated || parsed.data.date || null;
+          const readTime = KB.estimateReadTime(parsed.content);
+
+          documents.push({
+            path: entry.path,
+            title,
+            description,
+            tags,
+            category,
+            updated,
+            readTime,
+            content: parsed.content
+          });
+        } catch (error) {
+          console.warn('Failed to load article', entry.path, error);
+        }
+      }
+
+      documents.sort((a, b) => {
+        if (a.updated && b.updated) {
+          return new Date(b.updated).getTime() - new Date(a.updated).getTime();
+        }
+        if (a.updated) {
+          return -1;
+        }
+        if (b.updated) {
+          return 1;
+        }
+        return a.title.localeCompare(b.title);
+      });
+
+      return documents;
+    }
+
+    function applyFilters() {
+      if (!listContainer) {
+        return;
+      }
+
+      let results = state.docs.slice();
+      const query = state.query.toLowerCase();
+      if (query) {
+        results = results.filter(doc => {
+          const haystacks = [doc.title, doc.description, doc.category, doc.tags.join(' '), doc.content];
+          return haystacks.some(haystack => haystack && haystack.toLowerCase().includes(query));
+        });
+      }
+
+      if (state.activeTags.size) {
+        results = results.filter(doc => {
+          if (!doc.tags.length) {
+            return false;
+          }
+          return Array.from(state.activeTags).every(tag => doc.tags.some(docTag => docTag.toLowerCase() === tag.toLowerCase()));
+        });
+      }
+
+      renderActiveFilters();
+      renderList(results);
+      updateResultCount(results.length);
+      updateUrlState();
+    }
+
+    function renderList(results) {
+      listContainer.innerHTML = '';
+
+      if (!results.length) {
+        emptyState.hidden = false;
+        listContainer.hidden = true;
+        return;
+      }
+
+      emptyState.hidden = true;
+      listContainer.hidden = false;
+
+      const fragment = document.createDocumentFragment();
+      results.forEach(doc => {
+        const article = document.createElement('article');
+        article.className = 'kb-card';
+
+        const category = document.createElement('p');
+        category.className = 'category';
+        category.textContent = doc.category;
+        article.appendChild(category);
+
+        const title = document.createElement('h3');
+        const titleLink = document.createElement('a');
+        titleLink.href = `doc.html?doc=${encodeURIComponent(doc.path)}`;
+        titleLink.textContent = doc.title;
+        titleLink.className = 'read-more-link';
+        title.appendChild(titleLink);
+        article.appendChild(title);
+
+        const description = document.createElement('p');
+        description.textContent = doc.description;
+        article.appendChild(description);
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        if (doc.updated) {
+          const date = document.createElement('span');
+          date.textContent = `Updated ${KB.formatDate(doc.updated)}`;
+          meta.appendChild(date);
+        }
+        const readTime = document.createElement('span');
+        readTime.textContent = `${doc.readTime} min read`;
+        meta.appendChild(readTime);
+        article.appendChild(meta);
+
+        if (doc.tags.length) {
+          const tagList = document.createElement('div');
+          tagList.className = 'tags';
+        doc.tags.forEach(tag => {
+          const chip = document.createElement('span');
+          chip.textContent = formatTagLabel(tag);
+          tagList.appendChild(chip);
+        });
+          article.appendChild(tagList);
+        }
+
+        const link = document.createElement('a');
+        link.href = `doc.html?doc=${encodeURIComponent(doc.path)}`;
+        link.className = 'read-more';
+        link.innerHTML = 'Read article <svg aria-hidden="true" viewBox="0 0 20 20"><path fill="currentColor" d="M12.293 4.293a1 1 0 0 1 1.414 0l4 4a1 1 0 0 1 0 1.414l-4 4a1 1 0 1 1-1.414-1.414L14.586 10H4a1 1 0 1 1 0-2h10.586l-2.293-2.293a1 1 0 0 1 0-1.414z"></path></svg>';
+        article.appendChild(link);
+
+        fragment.appendChild(article);
+      });
+
+      listContainer.appendChild(fragment);
+    }
+
+    function buildTagCloud(docs) {
+      if (!tagCloud) {
+        return;
+      }
+
+      const tagCounts = new Map();
+      docs.forEach(doc => {
+        doc.tags.forEach(tag => {
+          const key = tag.toLowerCase();
+          tagCounts.set(key, (tagCounts.get(key) || 0) + 1);
+        });
+      });
+
+      tagCloud.innerHTML = '';
+
+      if (!tagCounts.size) {
+        const hint = document.createElement('p');
+        hint.textContent = 'Tags will appear once your articles include the "tags" front matter field.';
+        hint.className = 'tag-hint';
+        tagCloud.appendChild(hint);
+        return;
+      }
+
+      Array.from(tagCounts.keys())
+        .sort((a, b) => a.localeCompare(b))
+        .forEach(tag => {
+          const button = document.createElement('button');
+          const label = `${formatTagLabel(tag)} (${tagCounts.get(tag)})`;
+          button.type = 'button';
+          button.dataset.tag = tag;
+          button.textContent = label;
+          if (state.activeTags.has(tag)) {
+            button.dataset.active = 'true';
+          }
+          button.addEventListener('click', () => {
+            toggleTag(tag);
+          });
+          tagCloud.appendChild(button);
+        });
+
+      updateTagCloudSelection();
+    }
+
+    function toggleTag(tag) {
+      if (state.activeTags.has(tag)) {
+        state.activeTags.delete(tag);
+      } else {
+        state.activeTags.add(tag);
+      }
+      applyFilters();
+      updateTagCloudSelection();
+    }
+
+    function updateTagCloudSelection() {
+      if (!tagCloud) {
+        return;
+      }
+
+      tagCloud.querySelectorAll('button[data-tag]').forEach(button => {
+        const tag = button.dataset.tag;
+        button.dataset.active = state.activeTags.has(tag) ? 'true' : 'false';
+      });
+    }
+
+    function renderActiveFilters() {
+      if (!activeFilters) {
+        return;
+      }
+
+      activeFilters.innerHTML = '';
+      if (!state.activeTags.size) {
+        activeFilters.hidden = true;
+        return;
+      }
+
+      activeFilters.hidden = false;
+      state.activeTags.forEach(tag => {
+        const pill = document.createElement('span');
+        pill.className = 'filter-pill';
+        pill.textContent = `Tag: ${formatTagLabel(tag)}`;
+
+        const removeButton = document.createElement('button');
+        removeButton.type = 'button';
+        removeButton.setAttribute('aria-label', `Remove tag filter ${tag}`);
+        removeButton.textContent = '×';
+        removeButton.addEventListener('click', () => {
+          state.activeTags.delete(tag);
+          applyFilters();
+          updateTagCloudSelection();
+        });
+
+        pill.appendChild(removeButton);
+        activeFilters.appendChild(pill);
+      });
+    }
+
+    function updateArticleCount(count) {
+      if (articleCount) {
+        articleCount.textContent = count;
+      }
+    }
+
+    function updateResultCount(count) {
+      if (!resultCount) {
+        return;
+      }
+
+      const pieces = [];
+      pieces.push(`${count} article${count === 1 ? '' : 's'}`);
+      if (state.query) {
+        pieces.push(`matching “${state.query}”`);
+      }
+      if (state.activeTags.size) {
+        pieces.push(`filtered by ${Array.from(state.activeTags).map(formatTagLabel).join(', ')}`);
+      }
+
+      resultCount.textContent = pieces.join(' · ');
+    }
+
+    function showLoading(isLoading) {
+      if (!loadingIndicator) {
+        return;
+      }
+      loadingIndicator.hidden = !isLoading;
+    }
+
+    function showError(message) {
+      if (!errorState) {
+        alert(message);
+        return;
+      }
+      errorState.hidden = false;
+      errorState.textContent = message;
+      showLoading(false);
+    }
+
+    function renderFatalError(message) {
+      const fatalContainer = document.createElement('div');
+      fatalContainer.className = 'alert error';
+      fatalContainer.textContent = message;
+      app.innerHTML = '';
+      app.appendChild(fatalContainer);
+    }
+
+    function updateUrlState() {
+      const params = new URLSearchParams();
+      if (state.query) {
+        params.set('q', state.query);
+      }
+      if (state.activeTags.size) {
+        params.set('tags', Array.from(state.activeTags).join(','));
+      }
+
+      const queryString = params.toString();
+      const newUrl = queryString ? `${window.location.pathname}?${queryString}` : window.location.pathname;
+      window.history.replaceState({}, document.title, newUrl);
+    }
+    function formatTagLabel(tag) {
+      return tag
+        .split(/[-_\s]+/)
+        .map(part => (part ? part.charAt(0).toUpperCase() + part.slice(1) : ''))
+        .join(' ');
+    }
+
+  });
+})(window, document, window.KB || {});


### PR DESCRIPTION
## Summary
- replace the Hexo landing page with a knowledge base home that highlights search, filters, and contribution guidance
- add CSS and JavaScript utilities to load Markdown articles from the docs directory, expose tag filters, and keep the URL in sync
- create the article detail view and seed example Markdown guides for onboarding, contributing, deployment, and troubleshooting

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8d5a7579c832181126be4a2e41d56